### PR TITLE
class WikitextContent could not be converted to string

### DIFF
--- a/Sync.hooks.php
+++ b/Sync.hooks.php
@@ -45,7 +45,7 @@ class SyncHooks {
 					$syncWiki->editPage( $title, $autoTranslate->translate( $wikiPage->getId() ) );
 				} else {
 					$title = $wikiPage->getTitle()->getFullText();
-					$syncWiki->editPage( $title, $content );
+					$syncWiki->editPage( $title, $content->getNativeData() );
 				}
 			}
 		}

--- a/maintenance/importWiki.php
+++ b/maintenance/importWiki.php
@@ -64,7 +64,9 @@ class ImportWiki extends Maintenance {
 				echo "Successfully logged in\n";
 			}
 
-			$autoTranslate = new AutoTranslate( $wgSyncWiki['translate_to'] );
+			if ($wgSyncWiki['translate']) {
+				$autoTranslate = new AutoTranslate( $wgSyncWiki['translate_to'] );
+			}
 
 			foreach( $pages as $pageid => $pageName ) {
 				if ( $wgSyncWiki['translate'] ) {


### PR DESCRIPTION
It would like to fix 2 issues : 

first I got "Object of class WikitextContent could not be converted to string in vendor/nischayn22/mediawiki-api/src/MediaWikiApi.php on line 1022" when syncing a page

and after, when i tried the maintenance script, I got : class AutoTranslate not found
I didn't known where this class is defined, but as I didn't set the 'translate' config param, it should not be used